### PR TITLE
Validate MRN

### DIFF
--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -44,7 +44,7 @@ class DataRetrievalAction(
                              ) extends ActionTransformer[IdentifierRequest, OptionalDataRequest] {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] =
-    sessionRepository.get(mrn.value).map {
+    sessionRepository.get(mrn.toString).map {
       userAnswers =>
         OptionalDataRequest(request.request, request.identifier, userAnswers)
     }

--- a/app/forms/MovementReferenceNumberFormProvider.scala
+++ b/app/forms/MovementReferenceNumberFormProvider.scala
@@ -25,8 +25,6 @@ class MovementReferenceNumberFormProvider @Inject() extends Mappings {
 
   def apply(): Form[MovementReferenceNumber] =
     Form(
-      "value" -> text("movementReferenceNumber.error.required")
-        .verifying(maxLength(21, "movementReferenceNumber.error.length"))
-        .transform(MovementReferenceNumber(_), (_: MovementReferenceNumber).value)
+      "value" -> mrn("movementReferenceNumber.error.required", "movementReferenceNumber.error.invalid")
     )
 }

--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -18,7 +18,7 @@ package forms.mappings
 
 import play.api.data.FormError
 import play.api.data.format.Formatter
-import models.Enumerable
+import models.{Enumerable, MovementReferenceNumber}
 
 import scala.util.control.Exception.nonFatalCatch
 
@@ -92,4 +92,20 @@ trait Formatters {
       override def unbind(key: String, value: A): Map[String, String] =
         baseFormatter.unbind(key, value.toString)
     }
+
+  private[mappings] def mrnFormatter(requiredKey: String, invalidKey: String): Formatter[MovementReferenceNumber] =
+    new Formatter[MovementReferenceNumber] {
+
+      override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], MovementReferenceNumber] =
+        stringFormatter(requiredKey)
+          .bind(key, data)
+          .right.flatMap {
+            str =>
+              MovementReferenceNumber(str).map(Right.apply).getOrElse(Left(Seq(FormError(key, invalidKey))))
+          }
+
+      override def unbind(key: String, value: MovementReferenceNumber): Map[String, String] =
+        Map(key -> value.toString)
+    }
+
 }

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 
 import play.api.data.FieldMapping
 import play.api.data.Forms.of
-import models.Enumerable
+import models.{Enumerable, MovementReferenceNumber}
 
 trait Mappings extends Formatters with Constraints {
 
@@ -48,4 +48,7 @@ trait Mappings extends Formatters with Constraints {
                            requiredKey: String,
                            args: Seq[String] = Seq.empty): FieldMapping[LocalDate] =
     of(new LocalDateFormatter(invalidKey, allRequiredKey, twoRequiredKey, requiredKey, args))
+
+  protected def mrn(requiredKey: String, invalidKey: String): FieldMapping[MovementReferenceNumber] =
+    of(mrnFormatter(requiredKey, invalidKey))
 }

--- a/app/models/MovementReferenceNumber.scala
+++ b/app/models/MovementReferenceNumber.scala
@@ -16,25 +16,111 @@
 
 package models
 
+import MovementReferenceNumber._
 import play.api.libs.json._
 import play.api.mvc.PathBindable
+import scala.math.pow
 
-final case class MovementReferenceNumber (value: String)
+final case class MovementReferenceNumber (
+                                           year: String,
+                                           countryCode: String,
+                                           serial: String
+                                         ) {
+
+  override def toString: String = s"$year$countryCode$serial$checkCharacter"
+
+  val checkCharacter: String = {
+
+    val input = s"$year$countryCode$serial"
+
+    val remainder = input.zipWithIndex.map {
+      case (character, index) =>
+        characterWeights(character) * pow(2, index).toInt
+    }.sum % 11
+
+    (remainder % 10).toString
+  }
+}
 
 object MovementReferenceNumber {
 
-  implicit lazy val pathBindable: PathBindable[MovementReferenceNumber] = new PathBindable[MovementReferenceNumber] {
-    override def bind(key: String, value: String): Either[String, MovementReferenceNumber] =
-      Right(MovementReferenceNumber(value))
+  private val mrnFormat = """^(\d{2})([A-Z]{2})([A-Z0-9]{13})(\d)$""".r
 
-    override def unbind(key: String, value: MovementReferenceNumber): String =
-      value.value
+  def apply(input: String): Option[MovementReferenceNumber] = input match {
+    case mrnFormat(year, countryCode, serial, checkCharacter) =>
+
+      val mrn = MovementReferenceNumber(year, countryCode, serial)
+
+      if (mrn.checkCharacter == checkCharacter) {
+        Some(mrn)
+      } else {
+        None
+      }
+
+    case _ =>
+      None
   }
 
-  implicit lazy val reads: Reads[MovementReferenceNumber] =
-    __.read[String].map(MovementReferenceNumber(_))
+  implicit lazy val reads: Reads[MovementReferenceNumber] = {
+
+    import play.api.libs.json._
+
+    __.read[String].map(MovementReferenceNumber.apply).flatMap {
+      case Some(mrn) => Reads(_ => JsSuccess(mrn))
+      case None      => Reads(_ => JsError("Invalid Movement Reference Number"))
+    }
+  }
 
   implicit lazy val writes: Writes[MovementReferenceNumber] = Writes {
-    mrn => JsString(mrn.value)
+    mrn =>
+      JsString(mrn.toString)
   }
+
+  implicit def pathBindable: PathBindable[MovementReferenceNumber] = new PathBindable[MovementReferenceNumber] {
+
+    override def bind(key: String, value: String): Either[String, MovementReferenceNumber] =
+      MovementReferenceNumber.apply(value).toRight("Invalid Movement Reference Number")
+
+    override def unbind(key: String, value: MovementReferenceNumber): String =
+      value.toString
+  }
+
+  private val characterWeights = Map(
+    '0' -> 0,
+    '1' -> 1,
+    '2' -> 2,
+    '3' -> 3,
+    '4' -> 4,
+    '5' -> 5,
+    '6' -> 6,
+    '7' -> 7,
+    '8' -> 8,
+    '9' -> 9,
+    'A' -> 10,
+    'B' -> 12,
+    'C' -> 13,
+    'D' -> 14,
+    'E' -> 15,
+    'F' -> 16,
+    'G' -> 17,
+    'H' -> 18,
+    'I' -> 19,
+    'J' -> 20,
+    'K' -> 21,
+    'L' -> 23,
+    'M' -> 24,
+    'N' -> 25,
+    'O' -> 26,
+    'P' -> 27,
+    'Q' -> 28,
+    'R' -> 29,
+    'S' -> 30,
+    'T' -> 31,
+    'U' -> 32,
+    'V' -> 34,
+    'W' -> 35,
+    'X' -> 36,
+    'Y' -> 37,
+    'Z' -> 38
+  )
 }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -149,7 +149,7 @@ class CheckYourAnswersHelper(userAnswers: UserAnswers)(implicit messages: Messag
 
   def movementReferenceNumber: Row = Row(
     key     = Key(msg"movementReferenceNumber.checkYourAnswersLabel", classes = Seq("govuk-!-width-one-half")),
-    value   = Value(lit"${mrn.value}")
+    value   = Value(lit"${mrn.toString}")
   )
 
   private def yesOrNo(answer: Boolean): Content =

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -134,7 +134,7 @@ movementReferenceNumber.title = What is the Movement Reference Number (MRN)?
 movementReferenceNumber.heading = What is the Movement Reference Number (MRN)?
 movementReferenceNumber.checkYourAnswersLabel = Movement Reference Number
 movementReferenceNumber.error.required = Enter the Movement Reference Number
-movementReferenceNumber.error.length = Movement Reference Number must be 21 characters or less
+movementReferenceNumber.error.invalid = Enter a valid Movement Reference Number
 
 goodsLocation.title = Where are the goods?
 goodsLocation.heading = Where are the goods?

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -40,7 +40,7 @@ trait SpecBase extends FreeSpec with MustMatchers with GuiceOneAppPerSuite with 
     Mockito.reset(mockRenderer)
   }
 
-  val mrn = MovementReferenceNumber("id")
+  val mrn = MovementReferenceNumber("19", "GB", "1234567890123")
 
   def emptyUserAnswers = UserAnswers(mrn, Json.obj())
 

--- a/test/controllers/MovementReferenceNumberControllerSpec.scala
+++ b/test/controllers/MovementReferenceNumberControllerSpec.scala
@@ -88,7 +88,7 @@ class MovementReferenceNumberControllerSpec extends SpecBase with MockitoSugar w
 
       val request =
         FakeRequest(POST, movementReferenceNumberRoute)
-          .withFormUrlEncodedBody(("value", "answer"))
+          .withFormUrlEncodedBody(("value", "99IT9876AB88901209"))
 
       val result = route(application, request).value
 

--- a/test/forms/behaviours/FieldBehaviours.scala
+++ b/test/forms/behaviours/FieldBehaviours.scala
@@ -48,7 +48,7 @@ trait FieldBehaviours extends FormSpec with ScalaCheckPropertyChecks with Genera
       result.errors shouldEqual Seq(requiredError)
     }
 
-    "must  not bind blank values" in {
+    "must not bind blank values" in {
 
       val result = form.bind(Map(fieldName -> "")).apply(fieldName)
       result.errors shouldEqual Seq(requiredError)

--- a/test/generators/DomainModelGenerators.scala
+++ b/test/generators/DomainModelGenerators.scala
@@ -16,11 +16,11 @@
 
 package generators
 
-import java.time.{Instant, LocalDate, ZoneOffset}
+import java.time.LocalDate
 
 import models.MovementReferenceNumber
-import models.domain.messages.{ArrivalNotification, NormalNotification, SimplifiedNotification}
 import models.domain._
+import models.domain.messages.{ArrivalNotification, NormalNotification, SimplifiedNotification}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -44,7 +44,9 @@ trait ModelGenerators {
   implicit lazy  val arbitraryMovementReferenceNumber: Arbitrary[MovementReferenceNumber] =
     Arbitrary {
       for {
-        value <- arbitrary[String]
-      } yield MovementReferenceNumber(value)
+        year    <- Gen.choose(0, 99).map(y => f"$y%02d")
+        country <- Gen.pick(2, 'A' to 'Z')
+        serial  <- Gen.pick(13, ('A' to 'Z') ++ ('0' to '9'))
+      } yield MovementReferenceNumber(year, country.mkString, serial.mkString)
     }
 }

--- a/test/models/MovementReferenceNumberSpec.scala
+++ b/test/models/MovementReferenceNumberSpec.scala
@@ -18,13 +18,14 @@ package models
 
 import generators.ModelGenerators
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
+import org.scalacheck.Gen
+import org.scalatest.{EitherValues, FreeSpec, MustMatchers, OptionValues}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.{JsString, JsSuccess, Json}
 import play.api.mvc.PathBindable
 
 class MovementReferenceNumberSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks
-  with ModelGenerators with EitherValues {
+  with ModelGenerators with EitherValues with OptionValues {
 
   "a Movement Reference Number" - {
 
@@ -32,28 +33,19 @@ class MovementReferenceNumberSpec extends FreeSpec with MustMatchers with ScalaC
 
     "must bind from a url" in {
 
-      forAll(arbitrary[String], arbitrary[MovementReferenceNumber]) {
-        (key, mrn) =>
+      val mrn = MovementReferenceNumber("99IT9876AB88901209")
 
-          pathBindable.bind(key, mrn.value).right.value mustEqual mrn
-      }
-    }
+      val result = pathBindable.bind("mrn", "99IT9876AB88901209")
 
-    "must unbind to a url" in {
-
-      forAll(arbitrary[String], arbitrary[MovementReferenceNumber]) {
-        (key, mrn) =>
-
-          pathBindable.unbind(key, mrn) mustEqual mrn.value
-      }
+      result.right.value mustEqual mrn.value
     }
 
     "must deserialise" in {
 
-      forAll(arbitrary[String]) {
-        value =>
+      forAll(arbitrary[MovementReferenceNumber]) {
+        mrn =>
 
-          JsString(value).validate[MovementReferenceNumber] mustEqual JsSuccess(MovementReferenceNumber(value))
+          JsString(mrn.toString).as[MovementReferenceNumber] mustEqual mrn
       }
     }
 
@@ -62,7 +54,124 @@ class MovementReferenceNumberSpec extends FreeSpec with MustMatchers with ScalaC
       forAll(arbitrary[MovementReferenceNumber]) {
         mrn =>
 
-          Json.toJson(mrn) mustEqual JsString(mrn.value)
+          Json.toJson(mrn) mustEqual JsString(mrn.toString)
+      }
+    }
+
+    "must fail to bind from a string that isn't 18 characters long" in {
+
+      val gen = for {
+        digits <- Gen.choose[Int](1, 30).suchThat(_ != 18)
+        value  <- Gen.pick(digits, ('A' to 'Z') ++ ('0' to '9'))
+      } yield value.mkString
+
+      forAll(gen) {
+        invalidMrn =>
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind from a string that has any characters which aren't upper case or digits" in {
+
+      val gen: Gen[(MovementReferenceNumber, Int, Char)] = for {
+        mrn       <- arbitrary[MovementReferenceNumber]
+        index     <- Gen.choose(0, 17)
+        character <- arbitrary[Char]
+      } yield (mrn, index, character)
+
+      forAll(gen) {
+        case (mrn, index, character) =>
+
+          val validCharacters = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+          whenever (!validCharacters.contains(character)) {
+
+            val invalidMrn = mrn.toString.updated(index, character)
+
+            MovementReferenceNumber(invalidMrn) must not be defined
+          }
+      }
+    }
+
+    "must fail to bind from a string that does not have a digit as the first characters" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.alphaUpperChar) {
+        (mrn, upperCaseChar) =>
+
+          val invalidMrn = mrn.toString.updated(0, upperCaseChar)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind from a string that does not have a digit as the second characters" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.alphaUpperChar) {
+        (mrn, upperCaseChar) =>
+
+          val invalidMrn = mrn.toString.updated(1, upperCaseChar)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind a string that does not have an upper case character as the third character" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.numChar) {
+        (mrn, digit) =>
+
+          val invalidMrn = mrn.toString.updated(2, digit)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind a string that does not have an upper case character as the fourth character" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.numChar) {
+        (mrn, digit) =>
+
+          val invalidMrn = mrn.toString.updated(3, digit)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must build from a valid MRN" in {
+
+      MovementReferenceNumber("99IT9876AB88901209").value mustEqual MovementReferenceNumber("99", "IT", "9876AB8890120")
+      MovementReferenceNumber("18GB0000601001EB15").value mustEqual MovementReferenceNumber("18", "GB", "0000601001EB1")
+      MovementReferenceNumber("18GB0000601001EBD1").value mustEqual MovementReferenceNumber("18", "GB", "0000601001EBD")
+      MovementReferenceNumber("18IT02110010006A10").value mustEqual MovementReferenceNumber("18", "IT", "02110010006A1")
+      MovementReferenceNumber("18IT021100100069F4").value mustEqual MovementReferenceNumber("18", "IT", "021100100069F")
+      MovementReferenceNumber("18GB0000601001EBB5").value mustEqual MovementReferenceNumber("18", "GB", "0000601001EBB")
+    }
+
+    "must treat .apply and .toString as dual" in {
+
+      forAll(arbitrary[MovementReferenceNumber]) {
+        mrn =>
+
+          MovementReferenceNumber(mrn.toString).value mustEqual mrn
+      }
+    }
+
+    "must fail to bind from inputs with invalid check characters" in {
+
+      val checkDigitPosition = 17
+
+      val gen = for {
+        mrn               <- arbitrary[MovementReferenceNumber].map(_.toString)
+        invalidCheckDigit <- Gen.alphaChar suchThat (_ != mrn(checkDigitPosition))
+      } yield (mrn, invalidCheckDigit)
+
+      forAll(gen) {
+        case (mrn, invalidCheckDigit) =>
+
+          val invalidMrn = mrn.toString.updated(checkDigitPosition, invalidCheckDigit)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
       }
     }
   }

--- a/test/models/RichJsValueSpec.scala
+++ b/test/models/RichJsValueSpec.scala
@@ -24,8 +24,6 @@ import play.api.libs.json._
 
 class RichJsValueSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks with OptionValues with DomainModelGenerators {
 
-  implicit def dontShrink[A]: Shrink[A] = Shrink.shrinkAny
-
   val min = 2
   val max = 10
   val nonEmptyAlphaStr: Gen[String] = Gen.alphaStr.suchThat(_.nonEmpty)


### PR DESCRIPTION
MRNs have a specific format.  They consist of:
* the two-digit year (e.g. 19)
* the two-character country code (e.g. GB)
* 13 further characters which can be digits or uppercase chars
* A check digit calculated per ISO 6346

This PR changes the MovementReferenceNumber model to have an
apply method which will validate both the format and the check
digit, and changes both the Json Reads and the path bindable
to use it and fail if given an invalid MRN.  It also changes
the MovementReferenceNumber form to validate.