### PR TITLE
Update generator limits

### DIFF
--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.actions
 
-import generators.ModelGenerators
+import generators.Generators
 import models.requests.{IdentifierRequest, OptionalDataRequest}
 import models.{MovementReferenceNumber, UserAnswers}
 import org.mockito.Matchers._
@@ -37,7 +37,7 @@ import scala.concurrent.Future
 
 
 class DataRetrievalActionSpec extends FreeSpec with MustMatchers with GuiceOneAppPerSuite with ScalaFutures
-  with MockitoSugar with ModelGenerators with OptionValues {
+  with MockitoSugar with Generators with OptionValues {
 
   val sessionRepository: SessionRepository = mock[SessionRepository]
   val mrn: MovementReferenceNumber = arbitrary[MovementReferenceNumber].sample.value

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -16,7 +16,7 @@
 
 package forms.mappings
 
-import generators.ModelGenerators
+import generators.Generators
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
 import play.api.data.{Form, FormError}
@@ -38,7 +38,7 @@ object MappingsSpec {
   }
 }
 
-class MappingsSpec extends FreeSpec with MustMatchers with OptionValues with Mappings with ScalaCheckPropertyChecks with ModelGenerators {
+class MappingsSpec extends FreeSpec with MustMatchers with OptionValues with Mappings with ScalaCheckPropertyChecks with Generators {
 
   import MappingsSpec._
 

--- a/test/generators/DomainModelGenerators.scala
+++ b/test/generators/DomainModelGenerators.scala
@@ -166,11 +166,11 @@ trait DomainModelGenerators extends Generators {
 
   lazy val generatorTraderWithEoriAllValues: Gen[TraderWithEori] =
     for {
-      eori            <- arbitrary[String]
-      name            <- arbitrary[String]
-      streetAndNumber <- arbitrary[String]
-      postCode        <- arbitrary[String]
-      city            <- arbitrary[String]
+      eori            <- stringsWithMaxLength(17)
+      name            <- stringsWithMaxLength(35)
+      streetAndNumber <- stringsWithMaxLength(35)
+      postCode        <- stringsWithMaxLength(9)
+      city            <- stringsWithMaxLength(35)
     } yield TraderWithEori(eori, Some(name), Some(streetAndNumber), Some(postCode), Some(city), Some("GB"))
 
 }

--- a/test/generators/DomainModelGenerators.scala
+++ b/test/generators/DomainModelGenerators.scala
@@ -88,7 +88,8 @@ trait DomainModelGenerators extends Generators {
         transportIdentity <- stringsWithMaxLength(27)
         transportCountry  <- stringsWithMaxLength(2)
         endorsement       <- arbitrary[Endorsement]
-        containers        <- Gen.listOf(stringsWithMaxLength(17))
+        numberOfContainers  <- Gen.choose[Int](1, 99)
+        containers          <- Gen.listOfN(numberOfContainers, stringsWithMaxLength(17))
       } yield VehicularTranshipment(transportIdentity, transportCountry, endorsement, containers)
     }
 
@@ -96,8 +97,9 @@ trait DomainModelGenerators extends Generators {
     Arbitrary {
 
       for {
-        endorsement       <- arbitrary[Endorsement]
-        containers        <- Gen.nonEmptyListOf(stringsWithMaxLength(17))
+        endorsement         <- arbitrary[Endorsement]
+        numberOfContainers  <- Gen.choose[Int](1, 99)
+        containers          <- Gen.listOfN(numberOfContainers, stringsWithMaxLength(17))
       } yield ContainerTranshipment(endorsement, containers)
     }
 
@@ -140,7 +142,7 @@ trait DomainModelGenerators extends Generators {
         subPlace           <- Gen.option(stringsWithMaxLength(17))
         trader             <- arbitrary[Trader]
         presentationOffice <- stringsWithMaxLength(8)
-        events             <- arbitrary[Seq[EnRouteEvent]]
+        events             <- seqWithMaxLength[EnRouteEvent](9)
       } yield NormalNotification(mrn, place, date, subPlace, trader, presentationOffice, events)
     }
 
@@ -154,7 +156,7 @@ trait DomainModelGenerators extends Generators {
         approvedLocation   <- Gen.option(stringsWithMaxLength(17))
         trader             <- arbitrary[Trader]
         presentationOffice <- stringsWithMaxLength(8)
-        events             <- arbitrary[Seq[EnRouteEvent]]
+        events             <- seqWithMaxLength[EnRouteEvent](9)
       } yield SimplifiedNotification(mrn, place, date, approvedLocation, trader, presentationOffice, events)
     }
 

--- a/test/generators/DomainModelGenerators.scala
+++ b/test/generators/DomainModelGenerators.scala
@@ -127,7 +127,7 @@ trait DomainModelGenerators extends Generators {
         countryCode   <- stringsWithMaxLength(2)
         alreadyInNcts <- arbitrary[Boolean]
         eventDetails  <- arbitrary[EventDetails]
-        numberOfSeals <- Gen.choose[Int](0, 9999)
+        numberOfSeals <- Gen.choose[Int](0, 99)
         seals         <- Gen.listOfN(numberOfSeals, stringsWithMaxLength(20))
       } yield EnRouteEvent(place, countryCode, alreadyInNcts, eventDetails, seals)
     }

--- a/test/generators/Generators.scala
+++ b/test/generators/Generators.scala
@@ -20,7 +20,7 @@ import java.time.{Instant, LocalDate, ZoneOffset}
 
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen._
-import org.scalacheck.{Gen, Shrink}
+import org.scalacheck.{Arbitrary, Gen, Shrink}
 
 trait Generators extends UserAnswersGenerator with PageGenerators with ModelGenerators with UserAnswersEntryGenerators {
 
@@ -107,12 +107,11 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
       choose(0, vector.size - 1).flatMap(vector(_))
     }
 
-  def seqWithMaxLength[A](maxLength: Int): Gen[Seq[A]] =
+  def seqWithMaxLength[A](maxLength: Int)(implicit a: Arbitrary[A]): Gen[Seq[A]] =
     for {
       length <- choose(1, maxLength)
       seq <- listOfN(length, arbitrary[A])
     } yield seq
-
 
   def datesBetween(min: LocalDate, max: LocalDate): Gen[LocalDate] = {
 

--- a/test/generators/Generators.scala
+++ b/test/generators/Generators.scala
@@ -107,6 +107,13 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
       choose(0, vector.size - 1).flatMap(vector(_))
     }
 
+  def seqWithMaxLength[A](maxLength: Int): Gen[Seq[A]] =
+    for {
+      length <- choose(1, maxLength)
+      seq <- listOfN(length, arbitrary[A])
+    } yield seq
+
+
   def datesBetween(min: LocalDate, max: LocalDate): Gen[LocalDate] = {
 
     def toMillis(date: LocalDate): Long =

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -17,7 +17,6 @@
 package generators
 
 import models._
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 
 trait ModelGenerators {
@@ -26,9 +25,9 @@ trait ModelGenerators {
   implicit lazy val arbitraryTraderAddress: Arbitrary[TraderAddress] =
     Arbitrary {
       for {
-        buildingAndStreet <- arbitrary[String]
-        city <- arbitrary[String]
-        postcode <- arbitrary[String]
+        buildingAndStreet <- stringsWithMaxLength(35)
+        city <- stringsWithMaxLength(35)
+        postcode <- stringsWithMaxLength(9)
       } yield TraderAddress(buildingAndStreet, city, postcode)
     }
 

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -21,6 +21,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 
 trait ModelGenerators {
+  self: Generators =>
 
   implicit lazy val arbitraryTraderAddress: Arbitrary[TraderAddress] =
     Arbitrary {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -85,7 +85,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[TraderNamePage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(35).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -22,7 +22,8 @@ import org.scalacheck.Arbitrary.arbitrary
 import pages._
 import play.api.libs.json.{JsValue, Json}
 
-trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
+trait UserAnswersEntryGenerators extends PageGenerators {
+  self: Generators =>
 
   implicit lazy val arbitrarySealsChangedUserAnswersEntry: Arbitrary[(SealsChangedPage.type, JsValue)] =
     Arbitrary {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -45,7 +45,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[IncidentInformationPage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(350).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 
@@ -61,7 +61,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[EventPlacePage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(35).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 
@@ -69,7 +69,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[EventCountryPage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(2).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 
@@ -93,7 +93,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[TraderEoriPage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(17).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 
@@ -109,7 +109,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[AuthorisedLocationPage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(17).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 
@@ -117,7 +117,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[CustomsSubPlacePage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(17).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 
@@ -125,7 +125,7 @@ trait UserAnswersEntryGenerators extends PageGenerators {
     Arbitrary {
       for {
         page  <- arbitrary[PresentationOfficePage.type]
-        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+        value <- stringsWithMaxLength(8).suchThat(_.nonEmpty).map(Json.toJson(_))
       } yield (page, value)
     }
 

--- a/test/models/MovementReferenceNumberSpec.scala
+++ b/test/models/MovementReferenceNumberSpec.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import generators.ModelGenerators
+import generators.Generators
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers, OptionValues}
@@ -25,7 +25,7 @@ import play.api.libs.json.{JsString, JsSuccess, Json}
 import play.api.mvc.PathBindable
 
 class MovementReferenceNumberSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks
-  with ModelGenerators with EitherValues with OptionValues {
+  with Generators with EitherValues with OptionValues {
 
   "a Movement Reference Number" - {
 


### PR DESCRIPTION
- Update upper bound on generators for sequences and strings to limit the range.

- Update test which had no limits on the size of sequences generated 
