### PR TITLE
Scaffold - change set and remove to only require lower access Settable

### DIFF
--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -21,7 +21,7 @@ import java.time.LocalDateTime
 import derivable.Derivable
 import pages._
 import play.api.libs.json._
-import queries.Gettable
+import queries.{Gettable, Settable}
 
 import scala.util.{Failure, Success, Try}
 
@@ -33,13 +33,11 @@ final case class UserAnswers(id: MovementReferenceNumber, data: JsObject = Json.
   def get[A, B](derivable: Derivable[A, B])(implicit rds: Reads[A]): Option[B] =
     get(derivable: Gettable[A]).map(derivable.derive)
 
-  def set[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A]): Try[UserAnswers] = {
+  def set[A](page: Settable[A], value: A)(implicit writes: Writes[A]): Try[UserAnswers] = {
 
     val updatedData = data.setObject(page.path, Json.toJson(value)) match {
-      case JsSuccess(jsValue, _) =>
-        Success(jsValue)
-      case JsError(errors) =>
-        Failure(JsResultException(errors))
+      case JsSuccess(jsValue, _) => Success(jsValue)
+      case JsError(errors)       => Failure(JsResultException(errors))
     }
 
     updatedData.flatMap {
@@ -49,7 +47,7 @@ final case class UserAnswers(id: MovementReferenceNumber, data: JsObject = Json.
     }
   }
 
-  def remove[A](page: QuestionPage[A]): Try[UserAnswers] = {
+  def remove[A](page: Settable[A]): Try[UserAnswers] = {
 
     val updatedData = data.removeObject(page.path) match {
       case JsSuccess(jsValue, _) =>


### PR DESCRIPTION
For now, we're looking for comments on this where the main point of concern might be how the tests work. 

In particular, the`Query` is no longer a `Gettable` but we still need a way to get the data set for the assertion step of the tests. To achieve this we create an anonymous `Gettable` on the fly from a `Settable`. This means that the `QueryBehaviour`s now know implementation details of Settable. 

So the main questions are:
  1. _Is this a testing antipattern?_
  2. _If yes to (1), then how do we achieve the same goal?_