### PR TITLE
Scaffold - rename test variable to eliminate compiler warning.

### DIFF
--- a/test/models/MongoDateTimeFormatsSpec.scala
+++ b/test/models/MongoDateTimeFormatsSpec.scala
@@ -28,7 +28,7 @@ class MongoDateTimeFormatsSpec extends FreeSpec with MustMatchers with OptionVal
 
   "a LocalDateTime" - {
 
-    val date = LocalDate.of(2018, 2, 1).atStartOfDay
+    val testDate = LocalDate.of(2018, 2, 1).atStartOfDay
 
     val dateMillis = 1517443200000L
 
@@ -37,18 +37,18 @@ class MongoDateTimeFormatsSpec extends FreeSpec with MustMatchers with OptionVal
     )
 
     "must serialise to json" in {
-      val result = Json.toJson(date)
+      val result = Json.toJson(testDate)
       result mustEqual json
     }
 
     "must deserialise from json" in {
       val result = json.as[LocalDateTime]
-      result mustEqual date
+      result mustEqual testDate
     }
 
     "must serialise/deserialise to the same value" in {
-      val result = Json.toJson(date).as[LocalDateTime]
-      result mustEqual date
+      val result = Json.toJson(testDate).as[LocalDateTime]
+      result mustEqual testDate
     }
   }
 }


### PR DESCRIPTION
This change renames a variable in a test which the compiler incorrectly infers as being referenced in a non-interpolated string.