### PR TITLE
CTCTRADERS-215 Update the version of ReactiveMongo to 0.18.6.

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,26 +5,26 @@ object AppDependencies {
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "org.reactivemongo" %% "play2-reactivemongo"            % "0.18.3-play26",
-    "uk.gov.hmrc"       %% "logback-json-logger"            % "3.1.0",
-    "uk.gov.hmrc"       %% "play-health"                    % "3.14.0-play-26",
-    "uk.gov.hmrc"       %% "play-conditional-form-mapping"  % "0.2.0",
-    "uk.gov.hmrc"       %% "bootstrap-play-26"              % "1.0.0",
-    "uk.gov.hmrc"       %% "play-whitelist-filter"          % "2.0.0",
-    "uk.gov.hmrc"       %% "play-nunjucks"                  % "0.17.0-play-26",
-    "uk.gov.hmrc"       %% "play-nunjucks-viewmodel"        % "0.4.0",
-    "org.webjars.npm"   %  "govuk-frontend"                 % "3.3.0"
+    "org.reactivemongo" %% "play2-reactivemongo"           % "0.20.1-play26",
+    "uk.gov.hmrc"       %% "logback-json-logger"           % "3.1.0",
+    "uk.gov.hmrc"       %% "play-health"                   % "3.14.0-play-26",
+    "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "0.2.0",
+    "uk.gov.hmrc"       %% "bootstrap-play-26"             % "1.0.0",
+    "uk.gov.hmrc"       %% "play-whitelist-filter"         % "2.0.0",
+    "uk.gov.hmrc"       %% "play-nunjucks"                 % "0.17.0-play-26",
+    "uk.gov.hmrc"       %% "play-nunjucks-viewmodel"       % "0.4.0",
+    "org.webjars.npm"   % "govuk-frontend"                 % "3.3.0"
   )
 
   val test = Seq(
-    "org.scalatest"               %% "scalatest"           % "3.0.7",
-    "org.scalatestplus.play"      %% "scalatestplus-play"  % "3.1.2",
-    "org.pegdown"                 %  "pegdown"             % "1.6.0",
-    "org.jsoup"                   %  "jsoup"               % "1.10.3",
-    "com.typesafe.play"           %% "play-test"           % PlayVersion.current,
-    "org.mockito"                 %  "mockito-all"         % "1.10.19",
-    "org.scalacheck"              %% "scalacheck"          % "1.14.0",
-    "com.github.tomakehurst"      %  "wiremock-standalone" % "2.25.0"
+    "org.scalatest"          %% "scalatest"          % "3.0.7",
+    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2",
+    "org.pegdown"            % "pegdown"             % "1.6.0",
+    "org.jsoup"              % "jsoup"               % "1.10.3",
+    "com.typesafe.play"      %% "play-test"          % PlayVersion.current,
+    "org.mockito"            % "mockito-all"         % "1.10.19",
+    "org.scalacheck"         %% "scalacheck"         % "1.14.0",
+    "com.github.tomakehurst" % "wiremock-standalone" % "2.25.0"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test


### PR DESCRIPTION
This change to the ReactiveMongo fixes an issue in versions before 0.20.1 where a race condition at application start time, at the first request, or on mongo instances being recycled, the mongo connection may not be resolved.