### PR TITLE
CTCTRADERS-143: Update cleandown logic

### DIFF
--- a/app/pages/events/transhipments/TranshipmentTypePage.scala
+++ b/app/pages/events/transhipments/TranshipmentTypePage.scala
@@ -31,16 +31,8 @@ final case class TranshipmentTypePage(index: Int) extends QuestionPage[Transhipm
   override def toString: String = "transhipmentType"
 
   override def cleanup(value: Option[TranshipmentType], userAnswers: UserAnswers): Try[UserAnswers] = value match {
-    case Some(TranshipmentType.DifferentContainer) =>
-      userAnswers
-        .remove(TransportIdentityPage(index))
-        .flatMap(_.remove(TransportNationalityPage(index)))
 
-    case Some(TranshipmentType.DifferentVehicle) =>
-      userAnswers
-        .remove(ContainersQuery(index))
-
-    case None =>
+    case Some(_) | None =>
       userAnswers
         .remove(TransportIdentityPage(index))
         .flatMap(_.remove(TransportNationalityPage(index)))

--- a/app/pages/events/transhipments/TranshipmentTypePage.scala
+++ b/app/pages/events/transhipments/TranshipmentTypePage.scala
@@ -31,13 +31,10 @@ final case class TranshipmentTypePage(index: Int) extends QuestionPage[Transhipm
   override def toString: String = "transhipmentType"
 
   override def cleanup(value: Option[TranshipmentType], userAnswers: UserAnswers): Try[UserAnswers] = value match {
-
-    case Some(_) | None =>
+    case _ =>
       userAnswers
         .remove(TransportIdentityPage(index))
         .flatMap(_.remove(TransportNationalityPage(index)))
         .flatMap(_.remove(ContainersQuery(index)))
-
-    case _ => super.cleanup(value, userAnswers)
   }
 }

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import pages.QuestionPage
+import play.api.libs.json.{JsPath, Json}
+
+import scala.util.Try
+
+class UserAnswersSpec extends SpecBase {
+
+  case object TestPage extends QuestionPage[String] {
+    override def path: JsPath = JsPath \ "testPath"
+    override def cleanup(value: Option[String], userAnswers: UserAnswers): Try[UserAnswers] =
+      value match {
+        case Some("1") => userAnswers.remove(CleanupPage)
+        case _         => super.cleanup(value, userAnswers)
+      }
+  }
+
+  case object CleanupPage extends QuestionPage[String] {
+    override def path: JsPath = JsPath \ "testCleanupPath"
+  }
+
+  "UserAnswers" - {
+
+    "must update UserAnswers when set" in {
+
+      val userAnswers = UserAnswers(mrn)
+
+      val data = {
+        Json.obj(
+          "testPath" -> "test"
+        )
+      }
+
+      val result: UserAnswers = userAnswers.set(TestPage, "test").success.value
+
+      result mustBe UserAnswers(mrn, data, result.lastUpdated)
+    }
+
+    "must remove CleanupPath when testPage is set to 1" in {
+
+      val userAnswers = UserAnswers(mrn).set(CleanupPage, "testCleanupResult").success.value
+
+      val data = {
+        Json.obj(
+          "testPath" -> "1"
+        )
+      }
+
+      val result: UserAnswers = userAnswers.set(TestPage, "1").success.value
+
+      result mustBe UserAnswers(mrn, data, result.lastUpdated)
+    }
+
+    "must not remove CleanupPath when testPage is the same answer as before" in {
+
+      val userAnswers = UserAnswers(mrn)
+        .set(TestPage, "1")
+        .success
+        .value
+        .set(CleanupPage, "testCleanupResult")
+        .success
+        .value
+
+      val data = {
+        Json.obj(
+          "testPath"        -> "1",
+          "testCleanupPath" -> "testCleanupResult"
+        )
+      }
+
+      val result: UserAnswers = userAnswers.set(TestPage, "1").success.value
+
+      result mustBe UserAnswers(mrn, data, result.lastUpdated)
+    }
+
+  }
+
+}

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -45,7 +45,7 @@ class UserAnswersSpec extends SpecBase {
 
   "UserAnswers" - {
 
-    s"must run cleanup when given the answer of $testPageAnswer" in {
+    s"must run cleanup when the new answer is not equal to the existing answer" in {
 
       val userAnswers = emptyUserAnswers.set(TestCleanupPage, testCleanupPageAnswer).success.value
       val result      = userAnswers.set(TestPage, testPageAnswer).success.value
@@ -58,7 +58,7 @@ class UserAnswersSpec extends SpecBase {
       result mustBe UserAnswers(mrn, data, result.lastUpdated)
     }
 
-    s"must not run cleanup when given the answer of $testPageAnswer when the answer is the same in UserAnswers" in {
+    s"must not run cleanup when the new answer is equal to the existing answer" in {
 
       val userAnswers = emptyUserAnswers
         .set(TestPage, testPageAnswer)

--- a/test/navigation/CheckModeNavigatorSpec.scala
+++ b/test/navigation/CheckModeNavigatorSpec.scala
@@ -361,7 +361,6 @@ class CheckModeNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with
               .set(TransportNationalityPage(eventIndex), transportNationality)
               .success
               .value
-
             navigator
               .nextPage(TranshipmentTypePage(eventIndex), CheckMode, updatedUserAnswers)
               .mustBe(eventRoutes.CheckEventAnswersController.onPageLoad(updatedUserAnswers.id, eventIndex))

--- a/test/pages/GoodsLocationPageSpec.scala
+++ b/test/pages/GoodsLocationPageSpec.scala
@@ -17,6 +17,7 @@
 package pages
 
 import models.GoodsLocation
+import models.GoodsLocation._
 import models.UserAnswers
 import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
@@ -31,21 +32,39 @@ class GoodsLocationPageSpec extends PageBehaviours {
 
     beRemovable[GoodsLocation](GoodsLocationPage)
 
-    "must remove Authorised Location Code when the user selected Border Force office" in {
+    "must remove Authorised Location Code when the user changes to Border Force office" in {
 
-      forAll(arbitrary[UserAnswers]) {
-        answers =>
-          val result = answers.set(GoodsLocationPage, GoodsLocation.BorderForceOffice).success.value
+      forAll(arbitrary[UserAnswers], arbitrary[String]) {
+        (answers, location) =>
+          val result = answers
+            .set(GoodsLocationPage, AuthorisedConsigneesLocation)
+            .success
+            .value
+            .set(AuthorisedLocationPage, location)
+            .success
+            .value
+            .set(GoodsLocationPage, BorderForceOffice)
+            .success
+            .value
 
           result.get(AuthorisedLocationPage) must not be defined
       }
     }
 
-    "must remove Customs Sub Place when the user selects Authorised Consignees Location" in {
+    "must remove Customs Sub Place when the user changes to Authorised Consignees Location" in {
 
-      forAll(arbitrary[UserAnswers]) {
-        answers =>
-          val result = answers.set(GoodsLocationPage, GoodsLocation.AuthorisedConsigneesLocation).success.value
+      forAll(arbitrary[UserAnswers], arbitrary[String]) {
+        (answers, location) =>
+          val result = answers
+            .set(GoodsLocationPage, BorderForceOffice)
+            .success
+            .value
+            .set(AuthorisedLocationPage, location)
+            .success
+            .value
+            .set(GoodsLocationPage, AuthorisedConsigneesLocation)
+            .success
+            .value
 
           result.get(CustomsSubPlacePage) must not be defined
       }

--- a/test/pages/IsTraderAddressPlaceOfNotificationPageSpec.scala
+++ b/test/pages/IsTraderAddressPlaceOfNotificationPageSpec.scala
@@ -30,34 +30,40 @@ class IsTraderAddressPlaceOfNotificationPageSpec extends PageBehaviours {
 
     beRemovable[Boolean](IsTraderAddressPlaceOfNotificationPage)
 
-    "must clean down 'PlaceOfNotificationPage' when 'true'" in {
-      forAll(arbitrary[UserAnswers], stringsWithMaxLength(35)) {
-        (answers, placeOfNotification) =>
-          val ua = answers
-            .set(PlaceOfNotificationPage, placeOfNotification)
-            .success
-            .value
+    "must clean down 'PlaceOfNotificationPage'" - {
+      "when changes to 'true'" in {
+        forAll(arbitrary[UserAnswers], stringsWithMaxLength(35)) {
+          (answers, placeOfNotification) =>
+            val ua = answers
+              .set(IsTraderAddressPlaceOfNotificationPage, false)
+              .success
+              .value
+              .set(PlaceOfNotificationPage, placeOfNotification)
+              .success
+              .value
 
-          val result = ua.set(IsTraderAddressPlaceOfNotificationPage, true).success.value
+            val result = ua.set(IsTraderAddressPlaceOfNotificationPage, true).success.value
 
-          result.get(PlaceOfNotificationPage) must not be defined
+            result.get(PlaceOfNotificationPage) must not be defined
+        }
       }
-    }
 
-    "must clean down 'PlaceOfNotificationPage' when remove is called" in {
-      forAll(arbitrary[UserAnswers], stringsWithMaxLength(35)) {
-        (answers, placeOfNotification) =>
-          val ua = answers
-            .set(IsTraderAddressPlaceOfNotificationPage, false)
-            .success
-            .value
-            .set(PlaceOfNotificationPage, placeOfNotification)
-            .success
-            .value
+      "when remove is called" in {
+        forAll(arbitrary[UserAnswers], stringsWithMaxLength(35)) {
+          (answers, placeOfNotification) =>
+            val ua = answers
+              .set(IsTraderAddressPlaceOfNotificationPage, false)
+              .success
+              .value
+              .set(PlaceOfNotificationPage, placeOfNotification)
+              .success
+              .value
 
-          val result = ua.remove(IsTraderAddressPlaceOfNotificationPage).success.value
+            val result = ua.remove(IsTraderAddressPlaceOfNotificationPage).success.value
 
-          result.get(PlaceOfNotificationPage) must not be defined
+            result.get(PlaceOfNotificationPage) must not be defined
+        }
+
       }
     }
 

--- a/test/pages/events/EventReportedPageSpec.scala
+++ b/test/pages/events/EventReportedPageSpec.scala
@@ -34,14 +34,17 @@ class EventReportedPageSpec extends PageBehaviours {
     beRemovable[Boolean](EventReportedPage(index))
 
     "cleanup" - {
-      "must remove incident information when IsTranshipmentPage is true" in {
+      "must remove incident information when IsTranshipmentPage is change to true" in {
         forAll(arbitrary[UserAnswers], arbitrary[Boolean], arbitrary[String]) {
           (userAnswers, eventReportedAnswer, incidentInformationAnswer) =>
             val ua = userAnswers
-              .set(IsTranshipmentPage(index), true)
+              .set(IsTranshipmentPage(index), false)
               .success
               .value
               .set(IncidentInformationPage(index), incidentInformationAnswer)
+              .success
+              .value
+              .set(IsTranshipmentPage(index), true)
               .success
               .value
 
@@ -55,18 +58,19 @@ class EventReportedPageSpec extends PageBehaviours {
         }
       }
 
-      "must remove incident information data when EventReportedPage is true, IsTranshipmentPage is false, and the user has answered information" in {
-        forAll(arbitrary[UserAnswers], arbitrary[Boolean], arbitrary[String]) {
-          (userAnswers, eventReportedAnswer, incidentInformation) =>
-            val ua = userAnswers
+      "must remove incident information data when EventReportedPage changes to true, IsTranshipmentPage is false, and the user has answered information" in {
+        forAll(arbitrary[UserAnswers], arbitrary[String]) {
+          (userAnswers, incidentInformation) =>
+            val result = userAnswers
+              .set(EventReportedPage(index), false)
+              .success
+              .value
               .set(IsTranshipmentPage(index), false)
               .success
               .value
               .set(IncidentInformationPage(index), incidentInformation)
               .success
               .value
-
-            val result = ua
               .set(EventReportedPage(index), true)
               .success
               .value

--- a/test/pages/events/IsTranshipmentPageSpec.scala
+++ b/test/pages/events/IsTranshipmentPageSpec.scala
@@ -38,6 +38,9 @@ class IsTranshipmentPageSpec extends PageBehaviours {
         forAll(arbitrary[UserAnswers], arbitrary[String]) {
           (userAnswers, incidentInfo) =>
             val result = userAnswers
+              .set(IsTranshipmentPage(index), false)
+              .success
+              .value
               .set(IncidentInformationPage(index), incidentInfo)
               .success
               .value
@@ -54,6 +57,9 @@ class IsTranshipmentPageSpec extends PageBehaviours {
         forAll(arbitrary[UserAnswers], arbitrary[TranshipmentType]) {
           (userAnswers, transhipmentType) =>
             val result = userAnswers
+              .set(IsTranshipmentPage(index), true)
+              .success
+              .value
               .set(TranshipmentTypePage(index), transhipmentType)
               .success
               .value

--- a/test/pages/events/transhipments/TranshipmentTypePageSpec.scala
+++ b/test/pages/events/transhipments/TranshipmentTypePageSpec.scala
@@ -19,6 +19,7 @@ package pages.events.transhipments
 import generators.DomainModelGenerators
 import models.domain.Container
 import models.{TranshipmentType, UserAnswers}
+import models.TranshipmentType._
 import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
 import queries.ContainersQuery
@@ -36,18 +37,21 @@ class TranshipmentTypePageSpec extends PageBehaviours with DomainModelGenerators
     beRemovable[TranshipmentType](TranshipmentTypePage(index))
 
     "cleanup" - {
-      "must remove transport identity and nationality when there is an answer of Different Container" in {
+      "must remove transport identity and nationality when the answer change to Different Container" in {
 
         forAll(arbitrary[UserAnswers], arbitrary[String]) {
           (userAnswers, transportIdentity) =>
             val result = userAnswers
+              .set(TranshipmentTypePage(index), DifferentVehicle)
+              .success
+              .value
               .set(TransportIdentityPage(index), transportIdentity)
               .success
               .value
               .set(TransportNationalityPage(index), transportIdentity)
               .success
               .value
-              .set(TranshipmentTypePage(index), TranshipmentType.DifferentContainer)
+              .set(TranshipmentTypePage(index), DifferentContainer)
               .success
               .value
 
@@ -56,11 +60,14 @@ class TranshipmentTypePageSpec extends PageBehaviours with DomainModelGenerators
         }
       }
 
-      "must remove container numbers when there is an answer of Different Vehicle" in {
+      "must remove container numbers when the answer changes to Different Vehicle" in {
 
         forAll(arbitrary[UserAnswers], arbitrary[Container]) {
           (userAnswers, containerNumber) =>
             val result = userAnswers
+              .set(TranshipmentTypePage(index), DifferentContainer)
+              .success
+              .value
               .set(ContainerNumberPage(index, 0), containerNumber)
               .success
               .value


### PR DESCRIPTION
This pull requests enable the clean down logic to run only when the value is changed, allowing the user to go back in change mode and not change a value and keep future journey data in tact.

Updated previous tests so the test data resembles real life interactions