### PR TITLE
SuperShell fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ lazy val root = (project in file("."))
     ),
     uglifyCompressOptions          := Seq("unused=false", "dead_code=false"),
     pipelineStages in Assets       := Seq(concat, uglify),
+    useSuperShell in ThisBuild:= false,
     scalafmtOnCompile in ThisBuild := true
   )
 


### PR DESCRIPTION
disable supershell which allows the parms to show again when in SBT