### PR TITLE
Fix error thrown when "Changing" select option value

### DIFF
--- a/app/assets/javascripts/ctc.js
+++ b/app/assets/javascripts/ctc.js
@@ -35,7 +35,7 @@ if (accessibleAutocomplete && document.querySelector('.autocomplete') != null) {
     // =====================================================
     // Polyfill autocomplete once loaded
     // =====================================================
-    var checkForLoad = setInterval(checkForAutocompleteLoad, 500);
+    var checkForLoad = setInterval(checkForAutocompleteLoad, 50);
     var originalSelect = document.querySelector('select.autocomplete');
     var parentForm = upTo(originalSelect, 'form');
 
@@ -63,10 +63,6 @@ if (accessibleAutocomplete && document.querySelector('.autocomplete') != null) {
                 if(originalSelect.querySelectorAll('[selected]').length > 0 || originalSelect.value > ""){
 
                     var resetSelect = false;
-                    //TODO Need to check with Adam for this condition
-                   /* if(originalSelect.querySelectorAll('[selected]').length > 0 && originalSelect.querySelectorAll('[selected]')[0].text != combo.value){
-                        resetSelect = true;
-                    }*/
 
                     if(originalSelect.value){
                         if(combo.value != originalSelect.querySelector('option[value="' + originalSelect.value +'"]').text){

--- a/app/assets/javascripts/ctc.js
+++ b/app/assets/javascripts/ctc.js
@@ -63,9 +63,10 @@ if (accessibleAutocomplete && document.querySelector('.autocomplete') != null) {
                 if(originalSelect.querySelectorAll('[selected]').length > 0 || originalSelect.value > ""){
 
                     var resetSelect = false;
-                    if(originalSelect.querySelectorAll('[selected]').length > 0 && originalSelect.querySelectorAll('[selected]')[0].text != combo.value){
+                    //TODO Need to check with Adam for this condition
+                   /* if(originalSelect.querySelectorAll('[selected]').length > 0 && originalSelect.querySelectorAll('[selected]')[0].text != combo.value){
                         resetSelect = true;
-                    }
+                    }*/
 
                     if(originalSelect.value){
                         if(combo.value != originalSelect.querySelector('option[value="' + originalSelect.value +'"]').text){


### PR DESCRIPTION
Removes the additional, unrequired, check that causes the error to be thrown when a user changes a valid selection to another valid selection.

Increasing regularity of polling to identify if the autocomplete.js has loaded - resolving the issue that the selenium test missed by being faster than the original polling period.