### PR TITLE
Fixed randomly failing CountryListSpec test

### DIFF
--- a/test/models/CountryListSpec.scala
+++ b/test/models/CountryListSpec.scala
@@ -41,10 +41,15 @@ class CountryListSpec extends SpecBase with ScalaCheckPropertyChecks with Messag
     "getCountry" - {
       "must return correct country when in the fullList" in {
 
-        forAll(arbitrary[Vector[Country]], arbitrary[Country]) {
-          (countries, country) =>
-            val fullList: Vector[Country] = countries :+ country
-            CountryList(fullList).getCountry(country.code).value mustEqual country
+        forAll(arbitrary[Country]) {
+          country =>
+            val genUniqueCountryVector = arbitrary[Vector[Country]] suchThat (!_.exists(_.code == country.code))
+
+            forAll(genUniqueCountryVector) {
+              countries =>
+                val fullList: Vector[Country] = countries :+ country
+                CountryList(fullList).getCountry(country.code).value mustEqual country
+            }
         }
       }
 


### PR DESCRIPTION
When creating this tests I didnt consider that the generator would create a duplicate country code, this meant when comparing the generated country there was the possibility that the code was the same however the descriptions was different causing this test to fail intermittently.