### PR TITLE
CTCTRADERS-865: Remove toggles

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -48,9 +48,6 @@ class FrontendAppConfig @Inject()(configuration: Configuration) {
   lazy val baseDestinationUrl: String = configuration.get[Service]("microservice.services.destination").baseUrl
   lazy val referenceDataUrl: String   = configuration.get[Service]("microservice.services.referenceData").fullServiceUrl
 
-  lazy val featureToggleArrivalRejection: Boolean  = configuration.getOptional[Boolean]("feature-toggles.arrivalRejection").getOrElse(false)
-  lazy val featureToggleSimplifiedJourney: Boolean = configuration.getOptional[Boolean]("feature-toggles.simplifiedJourney").getOrElse(false)
-
   val env: String = configuration.get[String]("env")
 
   lazy val languageTranslationEnabled: Boolean =

--- a/app/controllers/ArrivalRejectionController.scala
+++ b/app/controllers/ArrivalRejectionController.scala
@@ -44,15 +44,11 @@ class ArrivalRejectionController @Inject()(
 
   def onPageLoad(arrivalId: ArrivalId): Action[AnyContent] = identify.async {
     implicit request =>
-      if (frontendAppConfig.featureToggleArrivalRejection) {
-        arrivalRejectionService.arrivalRejectionMessage(arrivalId).flatMap {
-          case Some(rejectionMessage) =>
-            val ArrivalRejectionViewModel(page, json) = ArrivalRejectionViewModel(rejectionMessage, appConfig.nctsEnquiriesUrl, arrivalId)
-            renderer.render(page, json).map(Ok(_))
-          case _ => Future.successful(Redirect(routes.TechnicalDifficultiesController.onPageLoad()))
-        }
-      } else {
-        Future.successful(Redirect(routes.UnauthorisedController.onPageLoad()))
+      arrivalRejectionService.arrivalRejectionMessage(arrivalId).flatMap {
+        case Some(rejectionMessage) =>
+          val ArrivalRejectionViewModel(page, json) = ArrivalRejectionViewModel(rejectionMessage, appConfig.nctsEnquiriesUrl, arrivalId)
+          renderer.render(page, json).map(Ok(_))
+        case _ => Future.successful(Redirect(routes.TechnicalDifficultiesController.onPageLoad()))
       }
   }
 }

--- a/app/controllers/GoodsLocationController.scala
+++ b/app/controllers/GoodsLocationController.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import config.FrontendAppConfig
 import controllers.actions._
 import forms.GoodsLocationFormProvider
 import javax.inject.Inject
@@ -40,8 +39,7 @@ class GoodsLocationController @Inject()(override val messagesApi: MessagesApi,
                                         requireData: DataRequiredAction,
                                         formProvider: GoodsLocationFormProvider,
                                         val controllerComponents: MessagesControllerComponents,
-                                        renderer: Renderer,
-                                        frontendAppConfig: FrontendAppConfig)(implicit ec: ExecutionContext)
+                                        renderer: Renderer)(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport
     with NunjucksSupport {
@@ -86,11 +84,9 @@ class GoodsLocationController @Inject()(override val messagesApi: MessagesApi,
               updatedAnswers <- Future.fromTry(request.userAnswers.set(GoodsLocationPage, value))
               _              <- sessionRepository.set(updatedAnswers)
             } yield
-              (value, frontendAppConfig.featureToggleSimplifiedJourney) match {
-                case (BorderForceOffice, _)                => Redirect(routes.CustomsSubPlaceController.onPageLoad(updatedAnswers.id, mode))
-                case (AuthorisedConsigneesLocation, true)  => Redirect(routes.AuthorisedLocationController.onPageLoad(updatedAnswers.id, mode))
-                case (AuthorisedConsigneesLocation, false) => Redirect(routes.UseDifferentServiceController.onPageLoad(updatedAnswers.id))
-
+              value match {
+                case BorderForceOffice            => Redirect(routes.CustomsSubPlaceController.onPageLoad(updatedAnswers.id, mode))
+                case AuthorisedConsigneesLocation => Redirect(routes.AuthorisedLocationController.onPageLoad(updatedAnswers.id, mode))
             }
         )
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -136,9 +136,3 @@ nunjucks {
   viewPaths = ["views"]
   libPaths = ["govuk-frontend"]
 }
-
-feature-toggles {
-  arrivalRejection = true
-  simplifiedJourney = true
-  
-}

--- a/test/controllers/ArrivalRejectionControllerSpec.scala
+++ b/test/controllers/ArrivalRejectionControllerSpec.scala
@@ -57,7 +57,7 @@ class ArrivalRejectionControllerSpec extends SpecBase with MockitoSugar with Jso
       (InvalidMrn, "Invalid MRN", "movementReferenceNumberRejection.error.invalid")
     ) foreach {
       case (errorType, errorPointer, errorKey) =>
-        s"return OK and the correct $errorPointer Rejection view for a GET when 'arrivalRejection' feature toggle set to true" in {
+        s"return OK and the correct $errorPointer Rejection view for a GET" in {
 
           when(mockRenderer.render(any(), any())(any()))
             .thenReturn(Future.successful(Html("")))
@@ -68,7 +68,6 @@ class ArrivalRejectionControllerSpec extends SpecBase with MockitoSugar with Jso
             .thenReturn(Future.successful(Some(ArrivalNotificationRejectionMessage(mrn.toString, LocalDate.now, None, None, errors))))
 
           val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
-            .configure(Configuration("feature-toggles.arrivalRejection" -> true))
             .overrides(
               bind[ArrivalRejectionService].toInstance(mockArrivalRejectionService)
             )
@@ -98,7 +97,7 @@ class ArrivalRejectionControllerSpec extends SpecBase with MockitoSugar with Jso
         }
     }
 
-    "return OK and the correct arrivalGeneralRejection view for a GET when 'arrivalRejection' feature toggle set to true" in {
+    "return OK and the correct arrivalGeneralRejection view for a GET" in {
 
       when(mockRenderer.render(any(), any())(any()))
         .thenReturn(Future.successful(Html("")))
@@ -109,7 +108,6 @@ class ArrivalRejectionControllerSpec extends SpecBase with MockitoSugar with Jso
         .thenReturn(Future.successful(Some(ArrivalNotificationRejectionMessage(mrn.toString, LocalDate.now, None, None, errors))))
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
-        .configure(Configuration("feature-toggles.arrivalRejection" -> true))
         .overrides(
           bind[ArrivalRejectionService].toInstance(mockArrivalRejectionService)
         )
@@ -144,7 +142,6 @@ class ArrivalRejectionControllerSpec extends SpecBase with MockitoSugar with Jso
         .thenReturn(Future.successful(None))
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
-        .configure(Configuration("feature-toggles.arrivalRejection" -> true))
         .overrides(
           bind[ArrivalRejectionService].toInstance(mockArrivalRejectionService)
         )
@@ -160,18 +157,6 @@ class ArrivalRejectionControllerSpec extends SpecBase with MockitoSugar with Jso
       application.stop()
     }
 
-    "redirect to Unauthorised page when 'arrivalRejection' feature toggle set to false" in {
-
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
-        .configure(Configuration("feature-toggles.arrivalRejection" -> false))
-        .build()
-      val request = FakeRequest(GET, routes.ArrivalRejectionController.onPageLoad(arrivalId).url)
-
-      val result = route(application, request).value
-
-      status(result) mustEqual SEE_OTHER
-
-      application.stop()
-    }
   }
+
 }

--- a/test/controllers/GoodsLocationControllerSpec.scala
+++ b/test/controllers/GoodsLocationControllerSpec.scala
@@ -108,19 +108,14 @@ class GoodsLocationControllerSpec extends SpecBase with MockitoSugar with Nunjuc
       application.stop()
     }
 
-    "must redirect to the correct page when Border Force is submitted and Simplified Journey toggle is false" in {
+    "must redirect to the correct page for Border Force Office when valid data is submitted" in {
 
       val mockSessionRepository = mock[SessionRepository]
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
-      val application =
-        applicationBuilder(userAnswers = Some(emptyUserAnswers))
-          .configure(Map("feature-toggles.simplifiedJourney" -> false))
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository)
-          )
-          .build()
+      val userAnswers = emptyUserAnswers.set(GoodsLocationPage, GoodsLocation.values.head).success.value
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       val request =
         FakeRequest(POST, goodsLocationRoute)
@@ -135,73 +130,14 @@ class GoodsLocationControllerSpec extends SpecBase with MockitoSugar with Nunjuc
       application.stop()
     }
 
-    "must redirect to the correct page when AuthorisedConsignee is submitted and Simplified Journey toggle is false" in {
+    "must redirect to the correct page for Authorised Consignees Location when valid data is submitted" in {
 
       val mockSessionRepository = mock[SessionRepository]
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
-      val application =
-        applicationBuilder(userAnswers = Some(emptyUserAnswers))
-          .configure(Map("feature-toggles.simplifiedJourney" -> false))
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository)
-          )
-          .build()
-
-      val request =
-        FakeRequest(POST, goodsLocationRoute)
-          .withFormUrlEncodedBody(("value", GoodsLocation.AuthorisedConsigneesLocation.toString))
-
-      val result = route(application, request).value
-
-      status(result) mustEqual SEE_OTHER
-
-      redirectLocation(result).value mustEqual s"/common-transit-convention-trader-arrival/${emptyUserAnswers.id}/use-ncts-service"
-
-      application.stop()
-    }
-
-    "must redirect to the correct page for Border Force Office when valid data is submitted and Simplified Journey toggle is true" in {
-
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-
-      val application =
-        applicationBuilder(userAnswers = Some(emptyUserAnswers))
-          .configure(Map("feature-toggles.simplifiedJourney" -> true))
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository)
-          )
-          .build()
-
-      val request =
-        FakeRequest(POST, goodsLocationRoute)
-          .withFormUrlEncodedBody(("value", GoodsLocation.BorderForceOffice.toString))
-
-      val result = route(application, request).value
-
-      status(result) mustEqual SEE_OTHER
-
-      redirectLocation(result).value mustEqual s"/common-transit-convention-trader-arrival/${emptyUserAnswers.id}/goods-approved-location"
-
-      application.stop()
-    }
-
-    "must redirect to the correct page for Authorised Consignees Location when valid data is submitted and Simplified Journey toggle is true" in {
-
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-
-      val application =
-        applicationBuilder(userAnswers = Some(emptyUserAnswers))
-          .configure(Map("feature-toggles.simplifiedJourney" -> true))
-          .overrides(
-            bind[SessionRepository].toInstance(mockSessionRepository)
-          )
-          .build()
+      val userAnswers = emptyUserAnswers.set(GoodsLocationPage, GoodsLocation.values.head).success.value
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       val request =
         FakeRequest(POST, goodsLocationRoute)


### PR DESCRIPTION
Removing features toggles because these are no longer needed.

app-config files can be updated once this is merged (see below)

https://github.com/hmrc/app-config-base/pull/3975
https://github.com/hmrc/app-config-development/pull/4213
https://github.com/hmrc/app-config-qa/pull/8300
https://github.com/hmrc/app-config-staging/pull/6015